### PR TITLE
Printing with custom page size and reading advanced printer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ I was involved in a project where I need to print from Node.JS. This is the reas
 * compatible with node-webkit v0.8.x and 0.9.2;
 * ```getPrinters()``` to enumerate all installed printers with current jobs and statuses;
 * ```getPrinter(printerName)``` to get a specific/default printer info with current jobs and statuses;
+* ```getPrinterDriverOptions(printerName)``` to get a specific/default printer driver options such as supported paper size and other info
+* ```getSelectedPaperSize(printerName)``` to get a specific/default printer default paper size from its driver options
 * ```getDefaultPrinterName()``` return the default printer name;
-* ```printDirect(stringData|bufferData, printerName, format, docname, success, error)``` to send a job to a specific/default printer;
-* ```getSupportedPrintFormats()``` to get all posibilbe print formats for printDirect method which depends on OS. ```RAW``` and ```TEXT``` are supported from all OS-es;
+* ```printDirect(stringData|bufferData, printerName, format, docname, options, success, error)``` to send a job to a specific/default printer, now supports [CUPS options](http://www.cups.org/documentation.php/options.html) passed in the form of a JS object (see `cancelJob.js` example);
+* ```getSupportedPrintFormats()``` to get all possible print formats for printDirect method which depends on OS. ```RAW``` and ```TEXT``` are supported from all OS-es;
 * ```getJob(printerName, jobId)``` to get a specific job info including job status;
 * ```setJob(printerName, jobId, command)``` to send a command to a job (e.g. ```'CANCEL'``` to cancel the job);
 * ```getSupportedJobCommands()``` to get supported job commands for setJob() depends on OS. ```'CANCEL'``` command is supported from all OS-es.

--- a/examples/cancelJob.js
+++ b/examples/cancelJob.js
@@ -7,6 +7,11 @@ printer.printDirect({
     data:"print from Node.JS buffer", // or simple String: "some text"
 	printer:printerName, // printer name
 	type: printerFormat, // type: RAW, TEXT, PDF, JPEG, .. depends on platform
+    options: // supported page sizes may be retrieved using getPrinterDriverOptions, supports CUPS printing options
+    {
+        media: 'Letter',
+        'fit-to-page': true
+    },
 	success:function(jobID){
 		console.log("sent to printer with ID: "+jobID);
         var jobInfo = printer.getJob(printerName, jobID);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1,8 +1,8 @@
 var printer_helper = {}
-    fs = require("fs")
-    child_process = require("child_process")
-    os = require("os")
-    path = require("path"),
+fs = require("fs")
+child_process = require("child_process")
+os = require("os")
+path = require("path"),
     native_lib_path = path.join(__dirname, '../build/Release/node_printer.node'),
     printer_helper;
 
@@ -18,7 +18,7 @@ module.exports.getPrinters = getPrinters;
 
 /** send data to printer
  */
-module.exports.printDirect = printDirect
+module.exports.printDirect = printDirect;
 
 /** Get supported print format for printDirect
  */
@@ -34,6 +34,7 @@ module.exports.getSupportedJobCommands = printer_helper.getSupportedJobCommands;
  */
 module.exports.getPrinter = getPrinter;
 module.exports.getSelectedPaperSize = getSelectedPaperSize;
+module.exports.getPrinterDriverOptions = getPrinterDriverOptions;
 
 /// Return default printer name
 module.exports.getDefaultPrinterName = printer_helper.getDefaultPrinterName;
@@ -53,17 +54,34 @@ function getPrinter(printerName)
     if(!printerName) {
         printerName = printer_helper.getDefaultPrinterName();
     }
-
-	return correctPrinterinfo(printer_helper.getPrinter(printerName));
+    var printer = printer_helper.getPrinter(printerName);
+    correctPrinterinfo(printer);
+    return printer;
 }
 
-// Finds selected paper size pertaining to the specific printer out of all supported ones in driver_options
+/** Get printer driver options includes advanced options like supported paper size
+ * @param printerName printer name to extract the info (default printer used if printer is not provided)
+ * @return printer driver info:
+ */
+function getPrinterDriverOptions(printerName)
+{
+    if(!printerName) {
+        printerName = printer_helper.getDefaultPrinterName();
+    }
+
+    return printer_helper.getPrinterDriverOptions(printerName);
+}
+
+/** Finds selected paper size pertaining to the specific printer out of all supported ones in driver_options
+ * @param printerName printer name to extract the info (default printer used if printer is not provided)
+ * @return selected paper size
+ */
 function getSelectedPaperSize(printerName){
-    var printer = getPrinter(printerName);
+    var driver_options = getPrinterDriverOptions(printerName);
     var selectedSize = "";
-    if (printer.driver_options && printer.driver_options.PageSize) {
-        Object.keys(printer.driver_options.PageSize).forEach(function(key){
-            if (printer.driver_options.PageSize[key] === "true")
+    if (driver_options && driver_options.PageSize) {
+        Object.keys(driver_options.PageSize).forEach(function(key){
+            if (driver_options.PageSize[key] === "true")
                 selectedSize = key;
         });
     }
@@ -72,12 +90,12 @@ function getSelectedPaperSize(printerName){
 
 function getJob(printerName, jobId)
 {
-	return printer_helper.getJob(printerName, jobId);
+    return printer_helper.getJob(printerName, jobId);
 }
 
 function setJob(printerName, jobId, command)
 {
-	return printer_helper.setJob(printerName, jobId, command);
+    return printer_helper.setJob(printerName, jobId, command);
 }
 
 function getPrinters(){
@@ -117,37 +135,34 @@ function correctPrinterinfo(printer) {
 }
 
 /*
-print raw data. This function is intend to be asynchronous
+ print raw data. This function is intend to be asynchronous
 
-parameters:
-   parameters - Object, parameters objects with the following structure:
-      data - String, mandatory, data to printer
-      printer - String, optional, name of the printer, if missing, will try to print to default printer
-      docname - String, optional, name of document showed in printer status
-      type - String, optional, only for wind32, data type, one of the RAW, TEXT
-      media - String, optional, page size, e.g. A4, Letter or other
-      fit_to_page - Bool, optional, used with `media` and if true scales the document to fit page
-      success - Function, optional, callback function
-      error - Function, optional, callback function if exists any error
+ parameters:
+ parameters - Object, parameters objects with the following structure:
+ data - String, mandatory, data to printer
+ printer - String, optional, name of the printer, if missing, will try to print to default printer
+ docname - String, optional, name of document showed in printer status
+ type - String, optional, only for wind32, data type, one of the RAW, TEXT
+ options - JS object with CUPS options, optional
+ success - Function, optional, callback function
+ error - Function, optional, callback function if exists any error
 
-   or
+ or
 
-   data - String, mandatory, data to printer
-   printer - String, optional, name of the printer, if missing, will try to print to default printer
-   docname - String, optional, name of document showed in printer status
-   type - String, optional, data type, one of the RAW, TEXT
-   media - String, optional, page size, e.g. A4, Letter or other
-   fit_to_page - Bool, optional, used with `media` and if true scales the document to fit page
-   success - Function, optional, callback function with first argument job_id
-   error - Function, optional, callback function if exists any error
-*/
+ data - String, mandatory, data to printer
+ printer - String, optional, name of the printer, if missing, will try to print to default printer
+ docname - String, optional, name of document showed in printer status
+ type - String, optional, data type, one of the RAW, TEXT
+ options - JS object with CUPS options, optional
+ success - Function, optional, callback function with first argument job_id
+ error - Function, optional, callback function if exists any error
+ */
 function printDirect(parameters){
     var data = parameters
         , printer
         , docname
         , type
-        , media
-        , fit_to_page
+        , options
         , success
         , error;
 
@@ -158,57 +173,50 @@ function printDirect(parameters){
         printer = parameters.printer;
         docname = parameters.docname;
         type = parameters.type;
-        media = parameters.media;
-        fit_to_page = parameters.fit_to_page;
+        options = parameters.options;
         success = parameters.success;
         error = parameters.error;
     }else{
         printer = arguments[1];
         type = arguments[2];
         docname = arguments[3];
-        media = arguments[4];
-        fit_to_page = arguments[5];
-        success = arguments[6];
-        error = arguments[7];
+        options = arguments[4];
+        success = arguments[5];
+        error = arguments[6];
     }
 
-   if(!type){
-      type = "RAW";
-   }
+    if(!type){
+        type = "RAW";
+    }
 
-   // Set default printer name
-   if(!printer) {
-       printer = printer_helper.getDefaultPrinterName();
-   }
+    // Set default printer name
+    if(!printer) {
+        printer = printer_helper.getDefaultPrinterName();
+    }
 
     type = type.toUpperCase();
 
-   if(!docname){
-      docname = "node print job";
-   }
+    if(!docname){
+        docname = "node print job";
+    }
 
-   if (!media){
-       media = "";
-   }
+    if (!options){
+        options = {};
+    }
 
-   if (fit_to_page && fit_to_page !== "false")
-       fit_to_page = "true";
-   else
-       fit_to_page = "false";
-
-   //TODO: check parameters type
-   if(printer_helper.printDirect){// call C++ binding
-      try{
-         var res = printer_helper.printDirect(data, printer, docname, type, media, fit_to_page, success, error);
-         if(res){
-            success(res);
-         }else{
-            error(Error("Something wrong in printDirect"));
-         }
-      }catch (e){
-         error(e);
-      }
+    //TODO: check parameters type
+    if(printer_helper.printDirect){// call C++ binding
+        try{
+            var res = printer_helper.printDirect(data, printer, docname, type, options);
+            if(res){
+                success(res);
+            }else{
+                error(Error("Something wrong in printDirect"));
+            }
+        }catch (e){
+            error(e);
+        }
     }else{
-      error("Not supported");
-   }
+        error("Not supported");
+    }
 }

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -33,6 +33,7 @@ module.exports.getSupportedJobCommands = printer_helper.getSupportedJobCommands;
 /** get printer info object. It includes all active jobs
  */
 module.exports.getPrinter = getPrinter;
+module.exports.getSelectedPaperSize = getSelectedPaperSize;
 
 /// Return default printer name
 module.exports.getDefaultPrinterName = printer_helper.getDefaultPrinterName;
@@ -54,6 +55,19 @@ function getPrinter(printerName)
     }
 
 	return correctPrinterinfo(printer_helper.getPrinter(printerName));
+}
+
+// Finds selected paper size pertaining to the specific printer out of all supported ones in driver_options
+function getSelectedPaperSize(printerName){
+    var printer = getPrinter(printerName);
+    var selectedSize = "";
+    if (printer.driver_options && printer.driver_options.PageSize) {
+        Object.keys(printer.driver_options.PageSize).forEach(function(key){
+            if (printer.driver_options.PageSize[key] === "true")
+                selectedSize = key;
+        });
+    }
+    return selectedSize;
 }
 
 function getJob(printerName, jobId)
@@ -108,55 +122,55 @@ print raw data. This function is intend to be asynchronous
 parameters:
    parameters - Object, parameters objects with the following structure:
       data - String, mandatory, data to printer
-      printer - String, mandatory, mane of the printer
+      printer - String, optional, name of the printer, if missing, will try to print to default printer
       docname - String, optional, name of document showed in printer status
       type - String, optional, only for wind32, data type, one of the RAW, TEXT
+      media - String, optional, page size, e.g. A4, Letter or other
+      fit_to_page - Bool, optional, used with `media` and if true scales the document to fit page
       success - Function, optional, callback function
       error - Function, optional, callback function if exists any error
 
    or
 
    data - String, mandatory, data to printer
-   printer - String, optional, mane of the printer, if missing, will try to print to default printer
+   printer - String, optional, name of the printer, if missing, will try to print to default printer
    docname - String, optional, name of document showed in printer status
    type - String, optional, data type, one of the RAW, TEXT
+   media - String, optional, page size, e.g. A4, Letter or other
+   fit_to_page - Bool, optional, used with `media` and if true scales the document to fit page
    success - Function, optional, callback function with first argument job_id
    error - Function, optional, callback function if exists any error
 */
 function printDirect(parameters){
-   var data = parameters
-      , printer
-      , docname
-      , type
-      , success
-      , error;
+    var data = parameters
+        , printer
+        , docname
+        , type
+        , media
+        , fit_to_page
+        , success
+        , error;
 
-   if(arguments.length==1){
-      //TODO: check parameters type
-      //if (typeof parameters )
-      data = parameters.data;
-      printer = parameters.printer;
-      docname = parameters.docname;
-      type = parameters.type;
-      success = parameters.success;
-      error = parameters.error;
-   }else{
-      printer = arguments[1];
-      type = arguments[2];
-      docname = arguments[3];
-      success = arguments[4];
-      error = arguments[5];
-   }
-
-   if(!success){
-      success = function(){};
-   }
-
-   if(!error){
-      error = function(err){
-         throw err;
-      };
-   }
+    if(arguments.length==1){
+        //TODO: check parameters type
+        //if (typeof parameters )
+        data = parameters.data;
+        printer = parameters.printer;
+        docname = parameters.docname;
+        type = parameters.type;
+        media = parameters.media;
+        fit_to_page = parameters.fit_to_page;
+        success = parameters.success;
+        error = parameters.error;
+    }else{
+        printer = arguments[1];
+        type = arguments[2];
+        docname = arguments[3];
+        media = arguments[4];
+        fit_to_page = arguments[5];
+        success = arguments[6];
+        error = arguments[7];
+    }
 
    if(!type){
       type = "RAW";
@@ -173,10 +187,19 @@ function printDirect(parameters){
       docname = "node print job";
    }
 
+   if (!media){
+       media = "";
+   }
+
+   if (fit_to_page && fit_to_page !== "false")
+       fit_to_page = "true";
+   else
+       fit_to_page = "false";
+
    //TODO: check parameters type
    if(printer_helper.printDirect){// call C++ binding
       try{
-         var res = printer_helper.printDirect(data, printer, docname, type, success, error);
+         var res = printer_helper.printDirect(data, printer, docname, type, media, fit_to_page, success, error);
          if(res){
             success(res);
          }else{

--- a/src/macros.hh
+++ b/src/macros.hh
@@ -66,6 +66,12 @@
     }                                                                          \
     v8::Local<v8::External> var = v8::Local<v8::External>::Cast(args[i]);
 
+#define REQUIRE_ARGUMENT_OBJECT(args, i, var)                                      \
+    if (args.Length() <= (i) || !args[i]->IsObject()) {                      \
+        RETURN_EXCEPTION_STR("Argument " #i " is not an object");       \
+    }                                                                          \
+    v8::Local<v8::Object> var = v8::Local<v8::Object>::Cast(args[i]);
+
 
 #define REQUIRE_ARGUMENT_FUNCTION(i, var)                                      \
     if (args.Length() <= (i) || !args[i]->IsFunction()) {                      \

--- a/src/node_printer.cc
+++ b/src/node_printer.cc
@@ -5,6 +5,7 @@ void initNode(v8::Handle<v8::Object> exports) {
   NODE_SET_METHOD(exports, "getPrinters", getPrinters);
   NODE_SET_METHOD(exports, "getDefaultPrinterName", getDefaultPrinterName);
   NODE_SET_METHOD(exports, "getPrinter", getPrinter);
+  NODE_SET_METHOD(exports, "getPrinterDriverOptions", getPrinterDriverOptions);
   NODE_SET_METHOD(exports, "getJob", getJob);
   NODE_SET_METHOD(exports, "setJob", setJob);
   NODE_SET_METHOD(exports, "printDirect", PrintDirect);

--- a/src/node_printer.hpp
+++ b/src/node_printer.hpp
@@ -33,6 +33,11 @@ MY_NODE_MODULE_CALLBACK(getDefaultPrinterName);
  */
 MY_NODE_MODULE_CALLBACK(getPrinter);
 
+/** Retrieve printer driver info
+ * @param printer name String
+ */
+MY_NODE_MODULE_CALLBACK(getPrinterDriverOptions);
+
 /** Retrieve job info
  *  @param printer name String
  *  @param job id Number

--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -6,6 +6,7 @@
 #include <sstream>
 
 #include <cups/cups.h>
+#include <cups/ppd.h>
 
 namespace
 {
@@ -119,6 +120,36 @@ namespace
         return "";
     }
 
+    void populatePpdOptions(v8::Handle<v8::Object> ppd_options, ppd_file_t  *ppd, ppd_group_t *group)
+    {
+
+      int		i, j;			/* Looping vars */
+      ppd_option_t	*option;		/* Current option */
+      ppd_choice_t	*choice;		/* Current choice */
+      ppd_group_t	*subgroup;		/* Current subgroup */
+
+
+      for (i = group->num_options, option = group->options; i > 0; i --, option ++)
+      {
+        MY_NODE_MODULE_ISOLATE_DECL
+        v8::Local<v8::Object> ppd_suboptions = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
+        for (j = option->num_choices, choice = option->choices;
+             j > 0;
+         j --, choice ++)
+        {
+
+            ppd_suboptions->Set(V8_STRING_NEW_UTF8(choice->choice),
+            choice->marked ? V8_STRING_NEW_UTF8("true") : V8_STRING_NEW_UTF8("false"));
+        }
+
+        ppd_options->Set(V8_STRING_NEW_UTF8(option->keyword), ppd_suboptions);
+      }
+
+      for (i = group->num_subgroups, subgroup = group->subgroups; i > 0; i --, subgroup ++)
+        populatePpdOptions(ppd_options, ppd, subgroup);
+    }
+
+
     /** Parse printer info object
      * @return error string.
      */
@@ -132,6 +163,30 @@ namespace
         {
             result_printer->Set(V8_STRING_NEW_UTF8("instance"), V8_STRING_NEW_UTF8(printer->instance));
         }
+
+        v8::Local<v8::Object> ppd_options = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
+
+        const char	*filename;		/* PPD filename */
+        ppd_file_t	*ppd;			/* PPD data */
+        ppd_group_t	*group;			/* Current group */
+        int i;
+        if ((filename = cupsGetPPD(printer->name)) != NULL)
+        {
+            if ((ppd = ppdOpenFile(filename)) != NULL)
+            {
+                 ppdMarkDefaults(ppd);
+                 cupsMarkOptions(ppd, printer->num_options, printer->options);
+
+                 for (i = ppd->num_groups, group = ppd->groups; i > 0; i--, group++)
+                 {
+                    populatePpdOptions(ppd_options, ppd, group);
+                 }
+                 ppdClose(ppd);
+            }
+            unlink(filename);
+        }
+        result_printer->Set(V8_STRING_NEW_UTF8("driver_options"), ppd_options);
+
         v8::Local<v8::Object> result_printer_options = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
         cups_option_t *dest_option = printer->options; 
         for(int j = 0; j < printer->num_options; ++j, ++dest_option)
@@ -342,6 +397,9 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
     REQUIRE_ARGUMENT_STRING(iArgs, 1, printername);
     REQUIRE_ARGUMENT_STRING(iArgs, 2, docname);
     REQUIRE_ARGUMENT_STRING(iArgs, 3, type);
+    REQUIRE_ARGUMENT_STRING(iArgs, 4, media);
+    REQUIRE_ARGUMENT_STRING(iArgs, 5, fit_to_page);
+
     std::string type_str(*type);
     FormatMapType::const_iterator itFormat = getPrinterFormatMap().find(type_str);
     if(itFormat == getPrinterFormatMap().end())
@@ -349,8 +407,17 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
         RETURN_EXCEPTION_STR("unsupported format type");
     }
     type_str = itFormat->second;
+
     int num_options = 0;
-    cups_option_t *options = NULL;
+    cups_option_t *options = (cups_option_t *)0;
+
+    /* Add options using cupsAddOption() */
+    //TODO: pass an array of arbitrary options instead of these two
+    if (strcmp(*media, "") != 0) {
+        num_options = cupsAddOption("media", *media, num_options, &options);
+        num_options = cupsAddOption("fit-to-page", *fit_to_page, num_options, &options);
+    }
+
     int job_id = cupsCreateJob(CUPS_HTTP_DEFAULT, *printername, *docname, num_options, options);
     if(job_id == 0) {
         RETURN_EXCEPTION_STR(cupsLastErrorString());

--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -120,14 +120,14 @@ namespace
         return "";
     }
 
+    /** Parses printer driver PPD options
+     */
     void populatePpdOptions(v8::Handle<v8::Object> ppd_options, ppd_file_t  *ppd, ppd_group_t *group)
     {
-
-      int		i, j;			/* Looping vars */
-      ppd_option_t	*option;		/* Current option */
-      ppd_choice_t	*choice;		/* Current choice */
-      ppd_group_t	*subgroup;		/* Current subgroup */
-
+      int		i, j;
+      ppd_option_t	*option;
+      ppd_choice_t	*choice;
+      ppd_group_t	*subgroup;
 
       for (i = group->num_options, option = group->options; i > 0; i --, option ++)
       {
@@ -149,6 +149,45 @@ namespace
         populatePpdOptions(ppd_options, ppd, subgroup);
     }
 
+    /** Parse printer driver options
+     * @return error string.
+     */
+    std::string parseDriverOptions(const cups_dest_t * printer, v8::Handle<v8::Object> ppd_options)
+    {
+        const char	*filename;
+        ppd_file_t	*ppd;
+        ppd_group_t	*group;
+        int i;
+
+        std::ostringstream error_str; // error string
+
+        if ((filename = cupsGetPPD(printer->name)) != NULL)
+        {
+            if ((ppd = ppdOpenFile(filename)) != NULL)
+            {
+                 ppdMarkDefaults(ppd);
+                 cupsMarkOptions(ppd, printer->num_options, printer->options);
+
+                 for (i = ppd->num_groups, group = ppd->groups; i > 0; i--, group++)
+                 {
+                    populatePpdOptions(ppd_options, ppd, group);
+                 }
+                 ppdClose(ppd);
+            }
+            else
+            {
+                error_str << "Unable to open PPD filename " << filename << " ";
+            }
+            unlink(filename);
+        }
+        else
+        {
+            error_str << "Unable to get CUPS PPD driver file. ";
+        }
+
+        return error_str.str();
+    }
+
 
     /** Parse printer info object
      * @return error string.
@@ -163,29 +202,6 @@ namespace
         {
             result_printer->Set(V8_STRING_NEW_UTF8("instance"), V8_STRING_NEW_UTF8(printer->instance));
         }
-
-        v8::Local<v8::Object> ppd_options = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
-
-        const char	*filename;		/* PPD filename */
-        ppd_file_t	*ppd;			/* PPD data */
-        ppd_group_t	*group;			/* Current group */
-        int i;
-        if ((filename = cupsGetPPD(printer->name)) != NULL)
-        {
-            if ((ppd = ppdOpenFile(filename)) != NULL)
-            {
-                 ppdMarkDefaults(ppd);
-                 cupsMarkOptions(ppd, printer->num_options, printer->options);
-
-                 for (i = ppd->num_groups, group = ppd->groups; i > 0; i--, group++)
-                 {
-                    populatePpdOptions(ppd_options, ppd, group);
-                 }
-                 ppdClose(ppd);
-            }
-            unlink(filename);
-        }
-        result_printer->Set(V8_STRING_NEW_UTF8("driver_options"), ppd_options);
 
         v8::Local<v8::Object> result_printer_options = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
         cups_option_t *dest_option = printer->options; 
@@ -284,6 +300,29 @@ MY_NODE_MODULE_CALLBACK(getPrinter)
     MY_NODE_MODULE_RETURN_VALUE(result_printer);
 }
 
+MY_NODE_MODULE_CALLBACK(getPrinterDriverOptions)
+{
+    MY_NODE_MODULE_HANDLESCOPE;
+    REQUIRE_ARGUMENTS(iArgs, 1);
+    REQUIRE_ARGUMENT_STRING(iArgs, 0, printername);
+
+    cups_dest_t *printers = NULL, *printer = NULL;
+    int printers_size = cupsGetDests(&printers);
+    printer = cupsGetDest(*printername, NULL, printers_size, printers);
+    v8::Local<v8::Object> driver_options = V8_VALUE_NEW_DEFAULT_V_0_11_10(Object);
+    if(printer != NULL)
+    {
+        parseDriverOptions(printer, driver_options);
+    }
+    cupsFreeDests(printers_size, printers);
+    if(printer == NULL)
+    {
+        // printer not found
+        RETURN_EXCEPTION_STR("Printer not found");
+    }
+    MY_NODE_MODULE_RETURN_VALUE(driver_options);
+}
+
 MY_NODE_MODULE_CALLBACK(getJob)
 {
     MY_NODE_MODULE_HANDLESCOPE;
@@ -368,7 +407,7 @@ MY_NODE_MODULE_CALLBACK(getSupportedPrintFormats)
 MY_NODE_MODULE_CALLBACK(PrintDirect)
 {
     MY_NODE_MODULE_HANDLESCOPE;
-    REQUIRE_ARGUMENTS(iArgs, 4);
+    REQUIRE_ARGUMENTS(iArgs, 5);
 
     // can be string or buffer
     if(iArgs.Length() <= 0)
@@ -397,8 +436,7 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
     REQUIRE_ARGUMENT_STRING(iArgs, 1, printername);
     REQUIRE_ARGUMENT_STRING(iArgs, 2, docname);
     REQUIRE_ARGUMENT_STRING(iArgs, 3, type);
-    REQUIRE_ARGUMENT_STRING(iArgs, 4, media);
-    REQUIRE_ARGUMENT_STRING(iArgs, 5, fit_to_page);
+    REQUIRE_ARGUMENT_OBJECT(iArgs, 4, print_options);
 
     std::string type_str(*type);
     FormatMapType::const_iterator itFormat = getPrinterFormatMap().find(type_str);
@@ -411,11 +449,15 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
     int num_options = 0;
     cups_option_t *options = (cups_option_t *)0;
 
-    /* Add options using cupsAddOption() */
-    //TODO: pass an array of arbitrary options instead of these two
-    if (strcmp(*media, "") != 0) {
-        num_options = cupsAddOption("media", *media, num_options, &options);
-        num_options = cupsAddOption("fit-to-page", *fit_to_page, num_options, &options);
+    v8::Local<v8::Array> props = print_options->GetPropertyNames();
+
+    for(unsigned int i = 0; i < props->Length(); i++) {
+
+        v8::Handle<v8::Value> key(props->Get(i));
+        v8::String::Utf8Value keyStr(key->ToString());
+        v8::String::Utf8Value valStr(print_options->Get(key)->ToString());
+
+        num_options = cupsAddOption(*keyStr, *valStr, num_options, &options);
     }
 
     int job_id = cupsCreateJob(CUPS_HTTP_DEFAULT, *printername, *docname, num_options, options);

--- a/src/node_printer_win.cc
+++ b/src/node_printer_win.cc
@@ -626,7 +626,7 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
 {
     MY_NODE_MODULE_HANDLESCOPE;
     //TODO: to move in an unique place win and posix input parameters processing
-    REQUIRE_ARGUMENTS(iArgs, 4);
+    REQUIRE_ARGUMENTS(iArgs, 6);
 
     // can be string or buffer
     if(iArgs.Length()<=0)


### PR DESCRIPTION
This commit adds support for retrieving printer supported media sizes as well as tons of other information via CUPS; it is made available through `getPrinter(<name>).driver_options`; furthermore, a user can now define page size via printDirect `media` option as well as manipulate scaling via `fit_to_page`.

Tested on OSX, not tested on Windows (CUPS is only for posix, but input parameters are passed to Windows too).

That was just a quick fix for my own project that I thought I'd share.