### PR TITLE
2 curls, no cups

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ or [direct from git](https://www.npmjs.org/doc/cli/npm-install.html):
     npm install git+https://github.com/tojocky/node-printer.git
 
 Ubuntu User :
-You need to install libcupsys2-dev package
-`sudo apt-get install libcupsys2-dev`
+You need to install libcups2-dev package
+`sudo apt-get install libcups2-dev`
 
 
 ### How to use:


### PR DESCRIPTION
The `libcupsys2-dev` package doesn't seem to exist. Using `libcups2-dev` will provide the required dependencies.