### PR TITLE
Added num_options initialization when options object is passed

### DIFF
--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -252,6 +252,7 @@ namespace
 
         /// Add options from v8 object
         CupsOptions(v8::Local<v8::Object> iV8Options) {
+        	num_options = 0;
             v8::Local<v8::Array> props = iV8Options->GetPropertyNames();
 
             for(unsigned int i = 0; i < props->Length(); ++i) {


### PR DESCRIPTION
This simple yet important change fixes segmentation faults (!) occuring on printDirect() if any options were passed.
This possibly affects printFile() too, I encountered these segfaults before I had possibility to test it (I don't really use or intend to use it in my app).