### PR TITLE
Update node version in CI (Travis and Appveyor)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   matrix:
-    - export NODE_VERSION="4.2"
-    - export NODE_VERSION="4.1"
+    - export NODE_VERSION="5.9"
+    - export NODE_VERSION="4.4"
     - export NODE_VERSION="0.10"
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ environment:
     - nodejs_version: "0.10"
     - nodejs_version: "0.11"
     - nodejs_version: "0.12"
+    - nodejs_version: "4.4"
+    - nodejs_version: "5.9"
     # io.js
     - nodejs_version: "1"
 


### PR DESCRIPTION
As per https://nodejs.org/en/download/releases/ 
Node 4.x uses V8 4.5.103.35
Node 5.x uses V8 4.6.85.31