### PR TITLE
add: ci prebuilts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 env:
   matrix:
+    - export NODE_VERSION="6.9"
     - export NODE_VERSION="5.9"
     - export NODE_VERSION="4.4"
     - export NODE_VERSION="0.10"
@@ -11,7 +12,7 @@ matrix:
 before_install:
   - git clone https://github.com/creationix/nvm.git ./.nvm
   - source ./.nvm/nvm.sh
-  - nvm install $NODE_VERSION
+  - nvm install $NODE_VERSION 64
   - echo $NODE_VERSION
   - nvm use $NODE_VERSION
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
@@ -22,15 +23,32 @@ before_install:
       sudo apt-get install -qq debhelper autotools-dev cups-ppdc libcups2-dev cups imagemagick ghostscript;
     fi
   - "export JOBS=4"
+  - npm install -g node-gyp node-pre-gyp
   - BUILD_ONLY=true npm install
 before_script:
   - git config --global user.name "Ion Lupascu"
   - git config --global user.email ionlupascu@gmail.com
+
+after_script:
+  - node-pre-gyp configure
+  - node-pre-gyp build package
+
+  - node-pre-gyp configure
+  - node-pre-gyp build package --target_arch=ia32
+
+# Need S3 Upload for Artifacts
+# addons:
+#   artifacts:
+#     debug: true
+#     paths:
+#     - ./build/stage/**/*.tar.gz
+
 git:
   depth: 1
 branches:
   only:
     - master
+
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -55,8 +55,24 @@ Make sure you have Python 2.x installed on your system. Windows users will also 
 
 from [npmjs.org](https://www.npmjs.org/package/printer)
 
-    npm install -g node-gyp
-    npm install printer --msvs_version=2013
+#### Prebuilt node builds
+```
+npm install node-printer --target_arch=ia32
+npm install node-printer --target_arch=x64
+```
+
+#### Prebuilt electron builds
+Say you are installing 1.4.5 electron. Please check the [Releases](https://github.com/tojocky/node-printer/releases) for supported Electron versions
+```
+npm install node-printer --runtime=electron --target=1.4.5 --target_arch=x64
+npm install node-printer --runtime=electron --target=1.4.5 --target_arch=ia32
+```
+
+#### For building after install
+```
+npm install -g node-gyp
+npm install printer --msvs_version=2013  --build-from-source=node_printer
+```
 
 or [direct from git](https://www.npmjs.org/doc/cli/npm-install.html):
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 # appveyor file
-# http://www.appveyor.com/docs/appveyor-yml
-
-# Try out "interactive-mode"
-os: Windows Server 2012 R2
 
 # build version format
 version: "{build}"
+
+platform: x64
+
+image: Visual Studio 2015
 
 # Set a known clone folder
 clone_folder: c:\projects\node-printer
@@ -24,6 +24,8 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4.4"
     - nodejs_version: "5.9"
+    - nodejs_version: "6.9"
+      build_electron: "true"
 
 matrix:
   fast_finish: true
@@ -32,12 +34,11 @@ matrix:
 
 # Get the latest stable version of Node 0.STABLE.latest
 install:
-  - ps: Install-Product node $env:nodejs_version
-  - cmd: SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
+  - ps: Install-Product node $env:nodejs_version x64
   - cmd: SET PATH=c:\python27;%PATH%
   - cmd: SET JOBS=4
   - cmd: SET BUILD_ONLY=true
-  - cmd: npm install -g node-gyp
+  - cmd: npm install -g node-gyp node-pre-gyp
   - npm install --msvs_version=2013
 
 test_script:
@@ -45,7 +46,14 @@ test_script:
   - npm --version
 #  - cmd: npm test
 
+after_test:
+  - node-gyp clean
+  - ps: ./tools/buildWindows.ps1
+
 build: off
+
+artifacts:
+  - path: 'build\stage\**\*.tar.gz'
 
 branches:
   only:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,17 @@
 {
   'targets': [
     {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
+    },
+    {
       'target_name': 'node_printer',
       'sources': [
         # is like "ls -1 src/*.cc", but gyp does not support direct patterns on

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -3,11 +3,11 @@ var printer_helper = {},
     child_process = require("child_process"),
     os = require("os"),
     path = require("path"),
-    native_lib_path = path.join(__dirname, '../build/Release/node_printer.node'),
+    binding_path = path.resolve(__dirname, './node_printer.node'),
     printer_helper;
 
-if(fs.existsSync(native_lib_path)) {
-    printer_helper = require(native_lib_path);
+if(fs.existsSync(binding_path)) {
+    printer_helper = require(binding_path);
 } else {
     printer_helper = require('./node_printer_'+process.platform+'_'+process.arch+'.node');
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build"
+  },
+  "binary": {
+    "module_name": "node_printer",
+    "module_path": "./lib/",
+    "host": "https://github.com/tojocky/node-printer/releases/download/",
+    "remote_path": "{version}"
   },
   "licenses": [
     {

--- a/tools/buildElectronWindows.ps1
+++ b/tools/buildElectronWindows.ps1
@@ -1,0 +1,20 @@
+#
+# Usage: buildElectronWindows.ps1 <version>
+#
+
+if ($args.Length -ne 1) {
+  echo "Must Supply only 1 argument - Version"
+  return
+}
+
+$version = $args[0]
+
+echo "Building Electron Version -> $version"
+
+node-gyp configure --target=$version --arch=x64 --dist-url=https://atom.io/download/atom-shell --module_name=node_printer --module_path=../lib/binding/node_printer/
+node-gyp build --target=$version --arch=x64 --dist-url=https://atom.io/download/atom-shell --module_name=node_printer --module_path=../lib/binding/node_printer/
+node-pre-gyp package --runtime=electron --target=$version --target_arch=x64
+
+node-gyp configure --target=$version --arch=ia32 --dist-url=https://atom.io/download/atom-shell --module_name=node_printer --module_path=../lib/binding/node_printer/
+node-gyp build --target=$version --arch=ia32 --dist-url=https://atom.io/download/atom-shell --module_name=node_printer --module_path=../lib/binding/node_printer/
+node-pre-gyp package --runtime=electron --target=$version --target_arch=ia32

--- a/tools/buildWindows.ps1
+++ b/tools/buildWindows.ps1
@@ -1,0 +1,16 @@
+# Build Win32 64bit
+node-pre-gyp configure
+node-pre-gyp build package
+
+# Build Win32 32bit
+node-pre-gyp configure
+node-pre-gyp build package --target_arch=ia32
+
+if ($env:build_electron -ne "true") {
+  echo "Skipping Electron Build as flag not set"
+  return
+}
+
+# Build Electron Versions
+./tools/buildElectronWindows.ps1 1.2.8
+./tools/buildElectronWindows.ps1 1.4.5


### PR DESCRIPTION
Following PR:

- adds prebuilts for Windows and for Linux/OSX (Need S3 Permissions which I think you can do that). The prebuilts are uploaded as artifacts so can be downloaded and staged for release manually.

- adds Node 6.9.1 LTS in the build

[Example - Appveyor](https://ci.appveyor.com/project/vasumahesh1/node-printer/build/12/job/0b3hubhxlkj1n0sb/artifacts)

For adding more electron versions use: `./tools/buildElectronWindows.ps1 <version>` in the script located in the tools/ folder. 

If I had a little more access, I could have done draft releases from CI. But I guess this is at least something for the prebuilts and we can look later ahead for improving this.

Feel free to test the prebuilt files. I have tried out the windows x64 node 6.9 and confident for the electron ones.