### PR TITLE
Fix job timestamps on 32 Bit systems

### DIFF
--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -113,9 +113,14 @@ namespace
 
         //Specific fields
         // Ecmascript store time in milliseconds, but time_t in seconds
-        result_printer_job->Set(V8_STRING_NEW_UTF8("completedTime"), V8_VALUE_NEW(Date, job->completed_time*1000));
-        result_printer_job->Set(V8_STRING_NEW_UTF8("creationTime"), V8_VALUE_NEW(Date, job->creation_time*1000));
-        result_printer_job->Set(V8_STRING_NEW_UTF8("processingTime"), V8_VALUE_NEW(Date, job->processing_time*1000));
+
+        double creationTime = ((double)job->creation_time) * 1000;
+        double completedTime = ((double)job->completed_time) * 1000;
+        double processingTime = ((double)job->processing_time) * 1000;
+
+        result_printer_job->Set(V8_STRING_NEW_UTF8("completedTime"), V8_VALUE_NEW(Date, completedTime));
+        result_printer_job->Set(V8_STRING_NEW_UTF8("creationTime"), V8_VALUE_NEW(Date, creationTime));
+        result_printer_job->Set(V8_STRING_NEW_UTF8("processingTime"), V8_VALUE_NEW(Date, processingTime));
 
         // No error. return an empty string
         return "";


### PR DESCRIPTION
Hi!

Great job with the repository, it's doing a solid job!

I found a bug on 32bit systems, where the job times are overflowing because their values are too high, e.g. the expected output:

```
{ id: 4,
  name: 'node print job',
  printerName: 'food-scoop-fastlane',
  user: 'root',
  format: 'RAW',
  priority: 50,
  size: 2,
  status: [ 'PRINTED' ],
  completedTime: 2017-11-15T15:05:58.000Z,
  creationTime: 2017-11-15T15:05:57.000Z,
  processingTime: 2017-11-15T15:05:57.000Z }
```

results in this:

```
{ id: 4,
  name: 'node print job',
  printerName: 'food-scoop-fastlane',
  user: 'root',
  format: 'RAW',
  priority: 50,
  size: 2,
  status: [ 'PRINTED' ],
  completedTime: 1969-12-19T14:44:29.808Z,
  creationTime: 1969-12-19T14:44:28.808Z,
  processingTime: 1969-12-19T14:44:28.808Z }
```

This pull request fixes this by using double values.

Would you be open to merge this? We will have to use a forked version until then.