### PR TITLE
fix deprecation warnings (v8::Isolate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/*
 *.node
 *.swp
 *.log
+package-lock.json

--- a/binding.gyp
+++ b/binding.gyp
@@ -22,6 +22,12 @@
         # sources
         '<!@(["python", "tools/getSourceFiles.py", "src", "cc"])'
       ],
+      'include_dirs' : [
+        "<!(node -e \"require('nan')\")"
+      ],
+      'cflags_cc+': [
+        "-Wno-cast-function-type"
+      ],
       'conditions': [
         # common exclusions
         ['OS!="linux"', {'sources/': [['exclude', '_linux\\.cc$']]}],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-node-gyp": "git://github.com/tojocky/grunt-node-gyp.git",
     "grunt-nw-gyp": "git://github.com/tojocky/grunt-nw-gyp.git",
+    "nan": "^2.13.2",
+    "node-pre-gyp": "^0.12.0",
     "nodeunit": "*"
   },
   "engines": {

--- a/src/macros.hh
+++ b/src/macros.hh
@@ -1,6 +1,7 @@
 #ifndef NODE_PRINTER_SRC_MACROS_H
 #define NODE_PRINTER_SRC_MACROS_H
 
+#include <nan.h>
 #include <node_version.h>
 
 // NODE_MODULE_VERSION was incremented for v0.11
@@ -53,9 +54,12 @@
 #endif
 
 
+#define V8_STR_UTF8VALUE(name, arg)                                             \
+  v8::String::Utf8Value name(MY_NODE_MODULE_ISOLATE_PRE arg);
+
 #define V8_STR_CONC(left, right)                              \
 	v8::String::Concat(V8_STRING_NEW_UTF8(left), V8_STRING_NEW_UTF8(right))
-		
+
 #define REQUIRE_ARGUMENTS(args, n)                                                   \
     if (args.Length() < (n)) {                                                 \
        RETURN_EXCEPTION_STR("Expected " #n " arguments");                       \
@@ -89,11 +93,11 @@
 
 #define REQUIRE_ARGUMENT_STRING(args, i, var)                                        \
     ARG_CHECK_STRING(args, i);                                                       \
-    v8::String::Utf8Value var(args[i]->ToString());
+    V8_STR_UTF8VALUE(var, args[i]->ToString());
 
 #define REQUIRE_ARGUMENT_STRINGW(args, i, var)                                        \
     ARG_CHECK_STRING(args, i);                                                       \
-    v8::String::Value var(args[i]->ToString());
+    v8::String::Value var(MY_NODE_MODULE_ISOLATE_PRE args[i]->ToString());
 
 
 #define OPTIONAL_ARGUMENT_FUNCTION(i, var)                                     \
@@ -109,7 +113,7 @@
 #define REQUIRE_ARGUMENT_INTEGER(args, i, var)                             \
     int var;                                                                   \
     if (args[i]->IsInt32()) {                                             \
-        var = args[i]->Int32Value();                                           \
+        var = Nan::To<int32_t>(args[i]).FromJust();                             \
     }                                                                          \
     else {                                                                     \
         RETURN_EXCEPTION_STR("Argument " #i " must be an integer");                 \

--- a/src/node_printer.cc
+++ b/src/node_printer.cc
@@ -22,9 +22,10 @@ NODE_MODULE(node_printer, initNode);
 
 bool getStringOrBufferFromV8Value(v8::Handle<v8::Value> iV8Value, std::string &oData)
 {
+    MY_NODE_MODULE_ISOLATE_DECL
     if(iV8Value->IsString())
     {
-        v8::String::Utf8Value data_str_v8(iV8Value->ToString());
+        V8_STR_UTF8VALUE(data_str_v8, iV8Value->ToString());
         oData.assign(*data_str_v8, data_str_v8.length());
         return true;
     }

--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -9,6 +9,8 @@
 #include <cups/cups.h>
 #include <cups/ppd.h>
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace
 {
     typedef std::map<std::string, int> StatusMapType;
@@ -259,12 +261,13 @@ namespace
 
         /// Add options from v8 object
         CupsOptions(v8::Local<v8::Object> iV8Options): num_options(0) {
+            MY_NODE_MODULE_ISOLATE_DECL
             v8::Local<v8::Array> props = iV8Options->GetPropertyNames();
 
             for(unsigned int i = 0; i < props->Length(); ++i) {
                 v8::Handle<v8::Value> key(props->Get(i));
-                v8::String::Utf8Value keyStr(key->ToString());
-                v8::String::Utf8Value valStr(iV8Options->Get(key)->ToString());
+                V8_STR_UTF8VALUE(keyStr, key->ToString());
+                V8_STR_UTF8VALUE(valStr, iV8Options->Get(key)->ToString());
 
                 num_options = cupsAddOption(*keyStr, *valStr, num_options, &_value);
             }

--- a/src/node_printer_win.cc
+++ b/src/node_printer_win.cc
@@ -680,7 +680,7 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
 
     std::string data;
     v8::Handle<v8::Value> arg0(iArgs[0]);
-    if (!getStringOrBufferFromV8Value(iArgs.GetIsolate(), arg0, data))
+    if (!getStringOrBufferFromV8Value(arg0, data))
     {
         RETURN_EXCEPTION_STR("Argument 0 must be a string or Buffer");
     }

--- a/src/node_printer_win.cc
+++ b/src/node_printer_win.cc
@@ -680,7 +680,7 @@ MY_NODE_MODULE_CALLBACK(PrintDirect)
 
     std::string data;
     v8::Handle<v8::Value> arg0(iArgs[0]);
-    if (!getStringOrBufferFromV8Value(arg0, data))
+    if (!getStringOrBufferFromV8Value(iArgs.GetIsolate(), arg0, data))
     {
         RETURN_EXCEPTION_STR("Argument 0 must be a string or Buffer");
     }


### PR DESCRIPTION
Uses the existing macros in `src/macros.hh` to update calls to `v8::String::Utf8Value`.

For the `Int32Value` warnings `Nan::To` is used.