### PR TITLE
fix compile error for Electron v7 and v8 (NodeJS v12.8 or v12.13)

### DIFF
--- a/src/macros.hh
+++ b/src/macros.hh
@@ -4,7 +4,7 @@
 #include <nan.h>
 #include <node_version.h>
 
-#if NODE_VERSION_AT_LEAST(13, 0, 0)
+#if NODE_VERSION_AT_LEAST(12, 0, 0)
 #  define MY_NODE_GET_OBJECT(object, id) object->Get(v8::Isolate::GetCurrent()->GetCurrentContext(), id).ToLocalChecked()
 #  define MY_NODE_SET_OBJECT(object, id, prop) object->Set(v8::Isolate::GetCurrent()->GetCurrentContext(), id, prop)
 #  define MY_NODE_SET_OBJECT_PROP(object, id, prop) MY_NODE_SET_OBJECT(object, V8_STRING_NEW_UTF8(id), prop)


### PR DESCRIPTION
Resolves #289, but I'm unsure how this change can affect users of the lib on different environments and NodeJS versions.

Tested on Mac OS 10.13 and Lubuntu 18.04 in an Electron v8.2.5 application with DNP Printer (using CUPS)